### PR TITLE
Fix shorthand TT-Specs again

### DIFF
--- a/timetable_kit/core.py
+++ b/timetable_kit/core.py
@@ -274,7 +274,11 @@ class TTSpec:
         new_csv.iloc[0, 0] = ""  # Blank out key_code
         # The following will add the stations as desired.
         # It creates duplicate indexes, so we must reset the index.
-        self.csv = pd.concat([new_csv, stations_df]).fillna("").reset_index(drop=True)
+        self.csv = (
+            pd.concat([new_csv, stations_df], ignore_index=True)
+            .fillna("")
+            .reset_index(drop=True)
+        )
         debug_print(1, "Augmented TTSpec:")
         debug_print(1, self.csv)
 

--- a/timetable_kit/specs_via/trto-ottw.csv
+++ b/timetable_kit/specs_via/trto-ottw.csv
@@ -1,0 +1,2 @@
+stations of 48,access,stations,50,52,40,42,644,44,46,646,54,48
+column-options,,,ardp,,ardp,,,,,,,

--- a/timetable_kit/specs_via/trto-ottw.toml
+++ b/timetable_kit/specs_via/trto-ottw.toml
@@ -1,0 +1,12 @@
+title = "Corridor Toronto-Ottawa"
+heading = "Toronto-Ottawa services"
+aria_label = "Toronto Ottawa"
+reference_date = "20240120"
+# This timetable gets split programmatically
+max_columns_per_page = 11
+landscape = true
+key_r = true
+key_d = true
+wheelchair_advance_notice = true
+montreal_airport_shuttle = true
+for_rpa = false


### PR DESCRIPTION
This minor fix makes the shorthand tt-specs work correctly again. The additional testing spec is optional.